### PR TITLE
Fix for Windows Unicode

### DIFF
--- a/python_scripts/backup_tool.py
+++ b/python_scripts/backup_tool.py
@@ -41,7 +41,7 @@ def extract_backup(backup_path, output_path, password=""):
             return
         manifest["password"] = password
         makedirs(output_path)
-        plistlib.writePlist(manifest, output_path + "/Manifest.plist")
+        plistlib.writePlist(manifest, output_path + "\Manifest.plist")
        
         mbdb.keybag = kb
         mbdb.extract_backup(output_path)

--- a/python_scripts/backups/backup4.py
+++ b/python_scripts/backups/backup4.py
@@ -117,7 +117,7 @@ class MBDB(object):
             # makedirs throw an exception, my code is ugly =)
             if record.is_directory():
                 try:
-                    os.makedirs(os.path.join(output_path, record.domain, record.path))
+                    os.makedirs(os.path.normcase(os.path.join(output_path, record.domain, record.path)))
                 except:
                     pass
 
@@ -143,7 +143,7 @@ class MBDB(object):
 
         # write output file
         out_file = re.sub(r'[:|*<>?"]', "_", out_file)
-        output_path = os.path.join(output_path, record.domain, out_file)
+        output_path = os.path.normcase(os.path.join(output_path, record.domain, out_file))
         print("Writing %s" % output_path)
         f2 = file(output_path, 'wb')
 


### PR DESCRIPTION
Fixes Windows Unicode, as it's very picky with backslashes. Normalises case in the directory creation and file write operations, and fixes a file write for the manifest.plist in the output. 

Long file paths cause backup_tool.py to error out on Windows, causing incomplete backup extraction. 
