### PR TITLE
Make makedirs work again

### DIFF
--- a/python_scripts/backups/backup4.py
+++ b/python_scripts/backups/backup4.py
@@ -118,7 +118,7 @@ class MBDB(object):
             if record.is_directory():
                 try:
                     # Convert path name to counter file system problems
-                    record_path=re.sub(r'[:|*<>?"]', "_", record_path)
+                    record_path = re.sub(r'[:|*<>?"]', "_", record.path)
                     os.makedirs(os.path.join(output_path, record.domain, record_path))
                 except:
                     pass


### PR DESCRIPTION
The converted path record_path was constructed from an empty variable.