### PR TITLE
Fixing "File not found" exceptions in backup scripts.

### DIFF
--- a/python_scripts/backups/backup10.py
+++ b/python_scripts/backups/backup10.py
@@ -177,7 +177,13 @@ class ManifestDB(object):
         out_file = re.sub(r'[:|*<>?"]', "_", out_file)
         output_path = os.path.join(output_path, record.domain, out_file)
         print("Writing %s" % output_path)
-        f2 = file(output_path, 'wb')
+
+        try:
+            f2 = file(output_path, 'wb')
+        
+        except:
+            warn("File %s could not be created (path too long?)" % output_path)
+            return
 
         aes = None
 

--- a/python_scripts/backups/backup4.py
+++ b/python_scripts/backups/backup4.py
@@ -147,7 +147,13 @@ class MBDB(object):
         out_file = re.sub(r'[:|*<>?"]', "_", out_file)
         output_path = os.path.join(output_path, record.domain, out_file)
         print("Writing %s" % output_path)
-        f2 = file(output_path, 'wb')
+
+        try:
+            f2 = file(output_path, 'wb')
+        
+        except:
+            warn("File %s could not be created (path too long?)" % output_path)
+            return
 
         aes = None
 


### PR DESCRIPTION
Happening e.g. on Windows environments, in case output path is too long or no write authorization is granted.