### PR TITLE
Fixes for iPhone 10.0.2 quirks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.project
+/.pydevproject
+/.settings/*
+*.pyc

--- a/python_scripts/backup_tool.py
+++ b/python_scripts/backup_tool.py
@@ -52,7 +52,15 @@ def extract_backup(backup_path, output_path, password=""):
         print "python keychain_tool.py -d \"%s\" \"%s\"" % (output_path + "/KeychainDomain/keychain-backup.plist", output_path + "/Manifest.plist")
 
     elif os.path.exists(backup_path + "/Manifest.db"):
+        
+        productVersionIos102 = False
+        productVersion = unicode(info.get("Product Version", "missing"))
+        if productVersion == "10.0.2":
+            productVersionIos102 = True
+        #print "Product Version 10.0.2 Detected? {}".format(productVersionIos102)
+                
         if 'ManifestKey' in manifest:
+            ios102 = True
             kb = Keybag.createWithBackupManifest(manifest, password, ios102=True)
         else:
             kb = Keybag.createWithBackupManifest(manifest, password)
@@ -69,7 +77,7 @@ def extract_backup(backup_path, output_path, password=""):
             wkey = manifest['ManifestKey'].data[4:]
             manifest_key = kb.unwrapKeyForClass(clas, wkey)
 
-        manifset_db = ManifestDB(backup_path, key=manifest_key)
+        manifset_db = ManifestDB(backup_path, key=manifest_key, ios102=productVersionIos102, backupPassword=password)
         manifset_db.keybag = kb
         manifset_db.extract_backup(output_path)
 


### PR DESCRIPTION
I have an iOS 10.0.2 backup that I really needed to access without having to restore it on one of the phones. This code does an amazing job but for the 10.0.2 quirks. namely:

1) The file column in the Manifest.db is encrypted, AES128CBC, and then base64 encoded with:
key = First 16 bytes of SHA1( backup_password + salt )
initializationVector = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
Added code only when version is 10.0.2 to process this column further to provide a plist.

2) The salt for the above step comes from Properties table in Manifest.db, there is also passwordHash stored in the table. Made these available to ManifestDB & related objects for use above.
